### PR TITLE
refactor: deduplicate SEH-protected memory reads into shared header

### DIFF
--- a/src/global-scanner.cpp
+++ b/src/global-scanner.cpp
@@ -2,6 +2,7 @@
 
 #include "global-scanner.hpp"
 #include "schema-manager.hpp"
+#include "safe-memory.hpp"
 #include "log.hpp"
 
 #include <Windows.h>
@@ -9,19 +10,6 @@
 #include <unordered_set>
 
 namespace globals {
-
-// ============================================================================
-// Safe memory read (SEH protected — we're dereferencing arbitrary .data values)
-// ============================================================================
-
-static bool safe_read_u64(uintptr_t addr, uint64_t& out) {
-    __try {
-        out = *reinterpret_cast<const uint64_t*>(addr);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
 
 // ============================================================================
 // PE section walking

--- a/src/interface-scanner.cpp
+++ b/src/interface-scanner.cpp
@@ -16,6 +16,7 @@
 #define LOG_TAG "interface-scanner"
 
 #include "interface-scanner.hpp"
+#include "safe-memory.hpp"
 #include "log.hpp"
 
 #include <Windows.h>
@@ -23,43 +24,6 @@
 #include <cstring>
 
 namespace interfaces {
-
-// ============================================================================
-// SEH-safe memory reads
-// ============================================================================
-
-static bool safe_read_u64(uintptr_t addr, uint64_t& out) {
-    __try {
-        out = *reinterpret_cast<const uint64_t*>(addr);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-static bool safe_read_bytes(const void* src, void* dst, size_t len) {
-    __try {
-        memcpy(dst, src, len);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-static bool safe_read_string(const char* src, char* dst, size_t max_len) {
-    __try {
-        size_t i = 0;
-        for (; i < max_len - 1; i++) {
-            dst[i] = src[i];
-            if (src[i] == '\0') return true;
-        }
-        dst[i] = '\0';
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        dst[0] = '\0';
-        return false;
-    }
-}
 
 // ============================================================================
 // Find InterfaceReg list head from CreateInterface function body

--- a/src/safe-memory.hpp
+++ b/src/safe-memory.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+/**
+ * dezlock-dump — SEH-Protected Memory Reads
+ *
+ * Shared inline helpers for safely reading arbitrary game memory.
+ * Uses MSVC __try/__except (SEH) since we're dereferencing pointers
+ * into another process's address space from the injected worker DLL.
+ */
+
+#include <Windows.h>
+#include <cstring>
+
+inline bool safe_read_u64(uintptr_t addr, uint64_t& out) {
+    __try {
+        out = *reinterpret_cast<const uint64_t*>(addr);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+inline bool safe_read_bytes(const void* src, void* dst, size_t len) {
+    __try {
+        memcpy(dst, src, len);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+inline bool safe_read_string(const char* src, char* dst, size_t max_len) {
+    __try {
+        size_t i = 0;
+        for (; i < max_len - 1; i++) {
+            dst[i] = src[i];
+            if (src[i] == '\0') return true;
+        }
+        dst[i] = '\0';
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        dst[0] = '\0';
+        return false;
+    }
+}

--- a/src/string-scanner.cpp
+++ b/src/string-scanner.cpp
@@ -10,6 +10,7 @@
 #define LOG_TAG "string-scanner"
 
 #include "string-scanner.hpp"
+#include "safe-memory.hpp"
 #include "log.hpp"
 
 #include <Windows.h>
@@ -18,19 +19,6 @@
 #include <algorithm>
 
 namespace strings {
-
-// ============================================================================
-// SEH-safe memory reads
-// ============================================================================
-
-static bool safe_read_bytes(const void* src, void* dst, size_t len) {
-    __try {
-        memcpy(dst, src, len);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
 
 // ============================================================================
 // PE section discovery


### PR DESCRIPTION
## Summary
- Extract `safe_read_u64`, `safe_read_bytes`, and `safe_read_string` from three scanner files into a shared header-only utility (`src/safe-memory.hpp`) with `inline` functions
- Remove duplicate local `static` implementations from `global-scanner.cpp`, `interface-scanner.cpp`, and `string-scanner.cpp`
- Net result: 48 lines added (new header), 63 lines removed (duplicates) = 15 fewer lines total

## Test plan
- [x] `cmake -B build -G "Visual Studio 17 2022" -A x64 && cmake --build build --config Release` builds successfully with no errors or warnings
- [ ] Verify runtime behavior by injecting into target process (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)