### PR TITLE
refactor: extract shared safe-memory utilities

### DIFF
--- a/src/global-scanner.cpp
+++ b/src/global-scanner.cpp
@@ -1,6 +1,7 @@
 #define LOG_TAG "global-scanner"
 
 #include "global-scanner.hpp"
+#include "safe-memory.hpp"
 #include "schema-manager.hpp"
 #include "log.hpp"
 
@@ -9,19 +10,6 @@
 #include <unordered_set>
 
 namespace globals {
-
-// ============================================================================
-// Safe memory read (SEH protected — we're dereferencing arbitrary .data values)
-// ============================================================================
-
-static bool safe_read_u64(uintptr_t addr, uint64_t& out) {
-    __try {
-        out = *reinterpret_cast<const uint64_t*>(addr);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
 
 // ============================================================================
 // PE section walking
@@ -170,7 +158,7 @@ GlobalMap scan(const std::unordered_map<std::string, schema::InheritanceInfo>& r
                 if (!is_plausible_pointer(val)) continue;
 
                 uint64_t vtable_ptr = 0;
-                if (!safe_read_u64(val, vtable_ptr)) continue;
+                if (!safe_mem::read_u64(val, vtable_ptr)) continue;
                 if (vtable_ptr == 0) continue;
 
                 auto it = vtable_to_class.find(vtable_ptr);

--- a/src/interface-scanner.cpp
+++ b/src/interface-scanner.cpp
@@ -16,6 +16,7 @@
 #define LOG_TAG "interface-scanner"
 
 #include "interface-scanner.hpp"
+#include "safe-memory.hpp"
 #include "log.hpp"
 
 #include <Windows.h>
@@ -25,43 +26,6 @@
 namespace interfaces {
 
 // ============================================================================
-// SEH-safe memory reads
-// ============================================================================
-
-static bool safe_read_u64(uintptr_t addr, uint64_t& out) {
-    __try {
-        out = *reinterpret_cast<const uint64_t*>(addr);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-static bool safe_read_bytes(const void* src, void* dst, size_t len) {
-    __try {
-        memcpy(dst, src, len);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-static bool safe_read_string(const char* src, char* dst, size_t max_len) {
-    __try {
-        size_t i = 0;
-        for (; i < max_len - 1; i++) {
-            dst[i] = src[i];
-            if (src[i] == '\0') return true;
-        }
-        dst[i] = '\0';
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        dst[0] = '\0';
-        return false;
-    }
-}
-
-// ============================================================================
 // Find InterfaceReg list head from CreateInterface function body
 // ============================================================================
 
@@ -69,7 +33,7 @@ static bool safe_read_string(const char* src, char* dst, size_t max_len) {
 // that loads the InterfaceReg* linked list head.
 static uintptr_t find_interface_list_head(uintptr_t func_addr) {
     uint8_t code[64];
-    if (!safe_read_bytes(reinterpret_cast<const void*>(func_addr), code, sizeof(code)))
+    if (!safe_mem::read_bytes(reinterpret_cast<const void*>(func_addr), code, sizeof(code)))
         return 0;
 
     for (size_t i = 0; i + 7 <= sizeof(code); i++) {
@@ -101,12 +65,12 @@ static uintptr_t find_interface_list_head(uintptr_t func_addr) {
         if (opcode == 0x8B) {
             // MOV — dereference to get the actual pointer
             uint64_t ptr_val = 0;
-            if (!safe_read_u64(target, ptr_val)) continue;
+            if (!safe_mem::read_u64(target, ptr_val)) continue;
             return static_cast<uintptr_t>(ptr_val);
         } else {
             // LEA — target is the static InterfaceReg* variable, dereference it
             uint64_t ptr_val = 0;
-            if (!safe_read_u64(target, ptr_val)) continue;
+            if (!safe_mem::read_u64(target, ptr_val)) continue;
             return static_cast<uintptr_t>(ptr_val);
         }
     }
@@ -160,7 +124,7 @@ static bool safe_call_factory(uint64_t create_fn, uintptr_t mod_base,
                 out_instance_rva = static_cast<uint32_t>(instance_addr - mod_base);
 
             uint64_t vtable_ptr = 0;
-            if (safe_read_u64(instance_addr, vtable_ptr)) {
+            if (safe_mem::read_u64(instance_addr, vtable_ptr)) {
                 if (vtable_ptr > mod_base)
                     out_vtable_rva = static_cast<uint32_t>(vtable_ptr - mod_base);
             }
@@ -191,9 +155,9 @@ static std::vector<InterfaceEntry> walk_interface_list(uintptr_t head, uintptr_t
         //   +0x10: InterfaceReg* m_pNext (8 bytes)
 
         uint64_t create_fn = 0, name_ptr = 0, next_ptr = 0;
-        if (!safe_read_u64(current + 0x00, create_fn)) break;
-        if (!safe_read_u64(current + 0x08, name_ptr)) break;
-        if (!safe_read_u64(current + 0x10, next_ptr)) break;
+        if (!safe_mem::read_u64(current + 0x00, create_fn)) break;
+        if (!safe_mem::read_u64(current + 0x08, name_ptr)) break;
+        if (!safe_mem::read_u64(current + 0x10, next_ptr)) break;
 
         // Validate name pointer
         if (name_ptr == 0) {
@@ -202,7 +166,7 @@ static std::vector<InterfaceEntry> walk_interface_list(uintptr_t head, uintptr_t
         }
 
         char name_buf[256] = {};
-        if (!safe_read_string(reinterpret_cast<const char*>(name_ptr), name_buf, sizeof(name_buf))) {
+        if (!safe_mem::read_string(reinterpret_cast<const char*>(name_ptr), name_buf, sizeof(name_buf))) {
             current = static_cast<uintptr_t>(next_ptr);
             continue;
         }

--- a/src/safe-memory.hpp
+++ b/src/safe-memory.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+/**
+ * dezlock-dump — SEH-protected memory read utilities
+ *
+ * Header-only inline functions for safely reading arbitrary game memory.
+ * All reads are wrapped in MSVC __try/__except to handle access violations
+ * gracefully, since we're dereferencing pointers from game .data/.rdata sections.
+ */
+
+#include <Windows.h>
+#include <cstdint>
+#include <cstring>
+
+namespace safe_mem {
+
+inline bool read_u64(uintptr_t addr, uint64_t& out) {
+    __try {
+        out = *reinterpret_cast<const uint64_t*>(addr);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+inline bool read_bytes(const void* src, void* dst, size_t len) {
+    __try {
+        memcpy(dst, src, len);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+inline bool read_string(const char* src, char* dst, size_t max_len) {
+    __try {
+        size_t i = 0;
+        for (; i < max_len - 1; i++) {
+            dst[i] = src[i];
+            if (src[i] == '\0') return true;
+        }
+        dst[i] = '\0';
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        dst[0] = '\0';
+        return false;
+    }
+}
+
+} // namespace safe_mem

--- a/src/string-scanner.cpp
+++ b/src/string-scanner.cpp
@@ -10,6 +10,7 @@
 #define LOG_TAG "string-scanner"
 
 #include "string-scanner.hpp"
+#include "safe-memory.hpp"
 #include "log.hpp"
 
 #include <Windows.h>
@@ -18,19 +19,6 @@
 #include <algorithm>
 
 namespace strings {
-
-// ============================================================================
-// SEH-safe memory reads
-// ============================================================================
-
-static bool safe_read_bytes(const void* src, void* dst, size_t len) {
-    __try {
-        memcpy(dst, src, len);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
 
 // ============================================================================
 // PE section discovery
@@ -234,7 +222,7 @@ static std::vector<CandidateString> collect_strings(uintptr_t mod_base) {
             // Try to read a string starting at pos
             char buf[520] = {};
             size_t max_read = (std::min)((size_t)(end - pos), sizeof(buf) - 1);
-            if (!safe_read_bytes(reinterpret_cast<const void*>(pos), buf, max_read)) {
+            if (!safe_mem::read_bytes(reinterpret_cast<const void*>(pos), buf, max_read)) {
                 pos += 16;
                 continue;
             }
@@ -295,7 +283,7 @@ static void scan_xrefs(std::vector<CandidateString>& candidates,
     for (const auto& sec : text_sections) {
         // Read entire section for fast scanning
         std::vector<uint8_t> code(sec.size);
-        if (!safe_read_bytes(reinterpret_cast<const void*>(sec.start), code.data(), sec.size))
+        if (!safe_mem::read_bytes(reinterpret_cast<const void*>(sec.start), code.data(), sec.size))
             continue;
 
         // Scan for LEA reg, [rip+disp32] and MOV reg, [rip+disp32]


### PR DESCRIPTION
## Summary
- Created `src/safe-memory.hpp` -- a header-only shared utility containing SEH-protected memory read functions (`read_u64`, `read_bytes`, `read_string`) under the `safe_mem` namespace.
- Removed duplicated `safe_read_u64` from `global-scanner.cpp` and `interface-scanner.cpp`.
- Removed duplicated `safe_read_bytes` from `interface-scanner.cpp` and `string-scanner.cpp`.
- Removed duplicated `safe_read_string` from `interface-scanner.cpp`.
- All three scanner files now include the shared header instead.

## Test plan
- [x] Full cmake configure + Release build passes with zero errors/warnings
- [ ] Manual injection test against game process to verify runtime behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)